### PR TITLE
Fix for Dart 2.13+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ wasm-pack.log
 worker/
 node_modules/
 .cargo-ok
+.dart_tool/
+.packages
+index.js
+index.js.deps
+index.js.map
+pubspec.lock

--- a/README.md
+++ b/README.md
@@ -24,9 +24,29 @@ cd projectname
 # run once to get dependencies
 pub get
 
-dart2js -O2 -o index.js index.dart
+dart2js -O2 --server-mode -o index.js index.dart
 ```
 
 That will compile your code into index.js, after which you can run `wrangler publish` to push it to Cloudflare.
 
 For more information on how Dart translates to JavaScript, see the [docs for dart2js](https://dart.dev/tools/dart2js) and the [interop guide](https://dart.dev/web/js-interop).
+
+#### Errors
+
+Dart `2.13.0` and above require the `dart2js --server-mode` flag when using native JavaScript classes. Server mode is used to compile JS to run on server side VMs such as nodejs. If this flag is not used, the following errors are displayed:
+
+```
+index.dart:4:7:
+Error: JS interop class 'Request' conflicts with natively supported class '_Request' in 'dart:html'.
+class Request {
+      ^
+index.dart:8:7:
+Error: JS interop class 'Response' conflicts with natively supported class '_Response' in 'dart:html'.
+class Response {
+      ^
+index.dart:13:7:
+Error: JS interop class 'FetchEvent' conflicts with natively supported class 'FetchEvent' in 'dart:html'.
+class FetchEvent {
+      ^
+Error: Compilation failed.
+```

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,3 +1,5 @@
 name: hello_workers
+environment:
+  sdk: '>=2.13.0 <3.0.0'
 dependencies:
-  js: 0.6.2
+  js: 0.6.3


### PR DESCRIPTION
There are two errors in the sample when running on Dart 2.13 or above.

The first is that a version constraint is required in `pubspec.yaml` for `pub get` to succeed. If the version constraint is missing, the following error is displayed:

```
pubspec.yaml has no lower-bound SDK constraint.
You should edit pubspec.yaml to contain an SDK constraint:

environment:
  sdk: '>=2.10.0 <3.0.0'

See https://dart.dev/go/sdk-constraint
```

The second issue is that native JavaScript APIs require using the `dart2js --server-mode` flag. If this flag isn't used, then errors show up:

```
index.dart:4:7:
Error: JS interop class 'Request' conflicts with natively supported class '_Request' in 'dart:html'.
class Request {
      ^
index.dart:8:7:
Error: JS interop class 'Response' conflicts with natively supported class '_Response' in 'dart:html'.
class Response {
      ^
index.dart:13:7:
Error: JS interop class 'FetchEvent' conflicts with natively supported class 'FetchEvent' in 'dart:html'.
class FetchEvent {
      ^
Error: Compilation failed.
```

@koeninger